### PR TITLE
Continue processing if Regulation Resource assigned to Bundle does not exist

### DIFF
--- a/createBundle.js
+++ b/createBundle.js
@@ -74,9 +74,18 @@ const execSubAccount = async (account) => {
       bundles.forEach(async (bundle) => {
         console.log(`${bundle.sid} => ${bundle.status}`);
         // Regulation Resourceを検索
-        const requlationResource = await twilioClient.numbers.v2.regulatoryCompliance.regulations(bundle.regulationSid).fetch();
-        if (bundle.status === "twilio-approved" && bundle.validUntil === null && NUMBER_TYPE === requlationResource.numberType)
-          fNoBundles = false;
+        twilioClient.numbers.v2.regulatoryCompliance
+          .regulations(bundle.regulationSid)
+          .fetch()
+          .then((regulation) => {
+            if (bundle.status === "twilio-approved" && bundle.validUntil === null && NUMBER_TYPE === requlation.numberType)
+              fNoBundles = false;
+          })
+          .catch((err) => {
+            // Bundleに紐付けられたRegulation Resourceが存在しない場合は処理を継続する
+            if (err.code !== 20404)
+              console.error(`*** ERROR ***\n${err}`);
+          });
       });
       if (fNoBundles) await addBundles(twilioClient, account);
     })


### PR DESCRIPTION
Bundle を検索する際、regulationSid プロパティで参照される Regulation Resource が既に存在しない場合がある。典型的なケースは、既に有効でない Regulation Resource が引き続き参照されている場合であり、これはすなわち、当該 Bundle 自体がもはや有効なものでないことを示す。このような Bundle が存在することで新たな Bundle 申請の処理を停止する理由は存在しないため、以下のような動作とする。

Bundle から regulationSid プロパティで参照された Regulation Resource の fetch に失敗した場合、そのエラーコードを参照する。これが 20404 である場合、例外を返さず処理を続行する。